### PR TITLE
Build libtest_shared.so with -fPIC

### DIFF
--- a/tests/apps/Makefile
+++ b/tests/apps/Makefile
@@ -29,6 +29,7 @@ all: $(APPS)
 test_shared: test_shared.o
 	g++ -o $@ $^ -ltest_shared -L.
 
+libtest_shared.o: CXXFLAGS+=-fPIC
 libtest_shared.so: libtest_shared.o
 	g++ -shared -o $@ $^
 


### PR DESCRIPTION
Currently building libtest_shared.so on x86-64 Linux fails with:
g++ -g -O0   -c -o libtest_shared.o libtest_shared.cc
g++ -shared -o libtest_shared.so libtest_shared.o
/usr/bin/ld: libtest_shared.o: relocation R_X86_64_32 against `.rodata'
can not be used when making a shared object; recompile with -fPIC
This patch adds -fPIC when compiling libtest_shared.cc.

Even on i686 Linux, shared libraries linked from objects compiled
without -fPIC will contain text relocations and Red Hat and Fedora Linux
would refuse to load them unless the shared library is tagged with a
"textrel_shlib_t" security label. (They try hard to keep memory either
writable or executable but not both)
see:
http://www.akkadia.org/drepper/textrelocs.html
http://www.iecc.com/linker/linker10.html
